### PR TITLE
chore: including eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/


### PR DESCRIPTION
Including eslintignore to do not trigger eslint rules to dependency or compiled files 